### PR TITLE
Create dockerfile

### DIFF
--- a/extract_datatourisme/dockerfile
+++ b/extract_datatourisme/dockerfile
@@ -1,0 +1,24 @@
+# Dockerfile
+# Utilisez l'image Python officielle
+FROM python:3.9-slim
+
+# Argument de construction pour spécifier le répertoire source
+ARG APP_DIR=/app
+
+# Créez et définissez le répertoire de travail
+WORKDIR $APP_DIR
+
+# Copiez d'abord seulement le fichier requirements.txt
+COPY requirements.txt $APP_DIR/requirements.txt
+
+# Installez les dépendances directement
+RUN pip install --no-cache-dir -r $APP_DIR/requirements.txt
+
+# Copiez le script Python
+COPY extract_datatourisme.py $APP_DIR/extract_datatourisme.py
+
+# Exposez le port sur lequel l'application Flask écoute
+EXPOSE 5002
+
+# Commande pour exécuter l'application Flask
+CMD python3 $APP_DIR/extract_datatourisme.py.py


### PR DESCRIPTION
Objectif: creation du dockerfile pour créer l'image docker de l'api d'extraction des données datatourisme

Exécution: 
Lors de la construction de l'image Docker, vous pouvez spécifier le répertoire source en utilisant l'option --build-arg :

docker build -t extract_datatourisme --build-arg APP_DIR=/path/to/your/app_directory .